### PR TITLE
Target ctypes

### DIFF
--- a/docs/source/ir/entities/constants.rst
+++ b/docs/source/ir/entities/constants.rst
@@ -1,5 +1,7 @@
 .. _sec-ir-constants:
 
+.. _sec-ir-enumtypes:
+
 Constants
 =========
 

--- a/docs/source/targets/ctypes/index.rst
+++ b/docs/source/targets/ctypes/index.rst
@@ -12,14 +12,26 @@ What is produced:
 
   * This is an expansion of the :ctypes:`Python/ctypes <>` module
 
-* C API Wrapper (``{meta.prefix}.py``)
+* Utility (``util.py``)
+
+  * Loading libraries using the :ctypes:`Python/ctypes <>` module
+  * Architecture check, which ensures that the target architecture matches the
+    architecture, the bindings were built on.
+
+* Initialisers (``__init__.py`` and ``raw/__init__.py``)
+
+  * Necessary files for initialising the Python module.
+
+* C API Wrappers for each module (``raw/{submodule}.py``)
 
   * Python module mapping the :ref:`sec-ir` to :class:`yace.target.ctypes`
+  * Entities are grouped in submodules by extracting the module name from the entity name.
+    It is assumed that entity names follow the format ``{meta.prefix}_{module}_{name}``.
   * :ref:`sec-ir-constants` become global variables in the ``{prefix}`` module,
     such as ``{prefix}.MIN_X``.
-  * EnumTypes  mapped to :class:`yace.targets.ctypes.ctypes_sugar.Enum`
-  * :ref:`sec-ir-structtypes` mapped to :class:`yace.targets.ctypes.ctypes_sugar.Structure`
-  * :ref:`sec-ir-uniontypes` mapped to :class:`yace.targets.ctypes.ctypes_sugar.Union`
+  * :ref:`Enum types<sec-ir-enumtypes>` mapped to :class:`yace.targets.ctypes.ctypes_sugar.Enum`
+  * :ref:`Struct types<sec-ir-structtypes>` mapped to :class:`yace.targets.ctypes.ctypes_sugar.Structure`
+  * :ref:`Union types<sec-ir-uniontypes>` mapped to :class:`yace.targets.ctypes.ctypes_sugar.Union`
 
 * Test (``{meta.prefix}_check.py``)
 

--- a/src/yace/ir/base.py
+++ b/src/yace/ir/base.py
@@ -91,6 +91,7 @@ class Entity(BaseModel):
 
     key: str  # The Yace-IR constructor keyword
     ant: Optional[dict] = Field(default_factory=dict)  # User annotations
+    module: Optional[str] = None # The module that the entity is part of
 
 
 class Documented(BaseModel):

--- a/src/yace/ir/cparser.py
+++ b/src/yace/ir/cparser.py
@@ -126,6 +126,11 @@ def typekind_to_typespec(
         case TypeKind.ULONGLONG:
             return datatypes.ULongLong(canonical=canonical, const=const), None
 
+        case TypeKind.FLOAT:
+            return datatypes.F32(canonical=canonical, const=const), None
+        case TypeKind.DOUBLE:
+            return datatypes.F64(canonical=canonical, const=const), None
+
         case TypeKind.ELABORATED | TypeKind.RECORD:
             *head, keyword, sym = tobj.spelling.split()
             match keyword:

--- a/src/yace/model.py
+++ b/src/yace/model.py
@@ -192,7 +192,7 @@ class ModelWalker(object):
         """
 
         res = [self.visit(cur, ancestors, depth)]
-        for attr in ["members", "parameters", "typ", "ret", "val"]:
+        for attr in ["members", "parameters", "typ", "ret", "val", "pointee", "array_typ"]:
             other = getattr(cur, attr, None)
             if other is None:
                 continue

--- a/src/yace/targets/ctypes/ctypes_sugar.py
+++ b/src/yace/targets/ctypes/ctypes_sugar.py
@@ -1,11 +1,6 @@
 """
 Addition to ctypes, making it slightly nicer to use, including:
 
-* gen_search_paths(libname)
-  * find_library() + pkg-config
-
-* load(libname)
-
 * typedef additions
   * c_log_double_t
   * c_uint128
@@ -14,7 +9,6 @@ Addition to ctypes, making it slightly nicer to use, including:
 
 TODO
 
-* Dict-accessor for structs / unions
 * Convenient typecast-helpers
 
 Copyright (c) 2023 Simon A. F. Lund <os@safl.dk>
@@ -22,80 +16,49 @@ SPDX-License-Identifier: BSD-3-Clause
 """
 
 import ctypes
-import ctypes.util
-import os
-import platform
-import subprocess
 
-SHARED_EXT = {
-    "linux": "so",
-    "windows": "dll",
-    "darwin": "dylib",
-}
+from typing import Generic, TypeAlias, TypeVar
+
 
 c_int128 = ctypes.c_ubyte * 16
 c_uint128 = c_int128
-void = None
-if ctypes.sizeof(ctypes.c_longdouble) == 8:
-    c_long_double_t = ctypes.c_longdouble
-else:
-    c_long_double_t = ctypes.c_ubyte * 8
+void: TypeAlias = None
 
 
 class Enum(object):
-    """Encapsulation of C enum"""
+	"""Encapsulation of C enum"""
 
-    pass
+	pass
 
 
 class Structure(ctypes.Structure):
-    """Encapsulation of C structs"""
+	"""Encapsulation of C structs"""
 
-    pass
+	def __getattr__(self, key):
+		return super().__getattr__(key)
+
+	pass
 
 
 class Union(ctypes.Union):
-    """Encapsulation of C union"""
+	"""Encapsulation of C union"""
 
-    pass
+	def __getattr__(self, key):
+		return super().__getattr__(key)
 
-
-def gen_search_paths(libname):
-    """
-    Yields search-paths for the shared library with the given 'libname'. It is
-    an extension of ``ctypes.util.find_library()`` using ``pkg-config``.
-    """
-
-    path = ctypes.util.find_library(libname)
-    if path:
-        yield path
-
-    try:
-        proc = subprocess.run(
-            ["pkg-config", libname, "--variable=libdir"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        if not proc.returncode:
-            ext = SHARED_EXT.get(platform.system().lower(), "so")
-
-            yield os.path.join(
-                proc.stdout.decode("utf-8").strip(), f"lib{libname}.{ext}"
-            )
-    except subprocess.CalledProcessError:
-        pass
+	pass
 
 
-def load(libname):
-    """Dynamically load the shared library named 'libname'"""
+T = TypeVar("T")
 
-    for spath in gen_search_paths(libname):
-        try:
-            lib = ctypes.CDLL(spath)
-            if lib:
-                return lib
-        except OSError:
-            continue
 
-    return None
+class Pointer(Generic[T], ctypes._Pointer):
+	"""Encapsulation of C pointer"""
+
+	def __class_getitem__(cls, *args):
+		ptrtype = ctypes.POINTER(*args)
+		alias = super().__class_getitem__(ptrtype)
+		return alias
+
+
+FunctionPointer = ctypes.CFUNCTYPE

--- a/src/yace/targets/ctypes/entity_define.h.template
+++ b/src/yace/targets/ctypes/entity_define.h.template
@@ -1,0 +1,7 @@
+{{ entity.sym }} = 
+{%- if entity.val.key == "str" -%}
+  "{{ entity.val.lit }}"
+{%- else -%}
+  {{entity.val.lit}}
+{%- endif -%}
+{%- if entity.doc %} # {{ entity.doc }}{% endif %}

--- a/src/yace/targets/ctypes/entity_enum.h.template
+++ b/src/yace/targets/ctypes/entity_enum.h.template
@@ -1,0 +1,27 @@
+class {{ entity.sym }}(Enum):
+{%- if entity.doc.__dict__.values()|map("length")|select|first %}
+	"""
+	{% for doc in [entity.doc.brief, entity.doc.description] if doc|length -%}
+	{{ doc | wrap("	") }}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+
+	{%- for tag in entity.doc.tags if tag not in entity.key -%}
+	{% if loop.first and [entity.doc.brief, entity.doc.description]|reject("==","")|list|length %}
+	{# A whitespace between description and tags #}
+	{%- endif -%}
+	{{ tag }}: 
+	{%- for key in entity.doc.tags[tag] %}
+	  {{ key }} {{ entity.doc.tags[tag][key] }}
+	{% endfor -%}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+	"""
+{%- endif -%}
+
+{%- for member in entity.members %}
+	{{ member.sym }} = {{ '0x%0x' % member.val.lit }}
+	{%- if member.doc.brief %} # {{ member.doc.brief }}{% endif %}
+{%- endfor %}

--- a/src/yace/targets/ctypes/entity_function_decl.h.template
+++ b/src/yace/targets/ctypes/entity_function_decl.h.template
@@ -1,0 +1,55 @@
+def {{ entity.sym }}(
+{%- for param in entity.parameters -%}
+{{ param.sym }}: {{ param.typ | emit_typespec }}{{ ", " if not loop.last else "" }}
+{%- endfor -%}
+) -> {{ entity.ret | emit_typespec }}:
+{%- if entity.doc.__dict__.values()|map("length")|select|first %}
+	"""
+	{% for doc in [entity.doc.brief, entity.doc.description] if doc|length -%}
+	{{ doc | wrap("	") }}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+
+	{%- for tag in entity.doc.tags if tag not in ["param", "return"] -%}
+	{% if loop.first and [entity.doc.brief, entity.doc.description]|reject("==","")|list|length %}
+	{# A whitespace between description and tags #}
+	{%- endif -%}
+	{{ tag }}: 
+	{%- for key in entity.doc.tags[tag] %}
+	  {{ key }} {{ entity.doc.tags[tag][key] }}
+	{% endfor -%}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+
+	{%- if entity.parameters | length %}
+	Args:
+	{%- for param in entity.parameters %}
+	  {{param.sym}} ({{ param.typ | emit_typespec }})
+	  {%- if param.sym in entity.doc.tags.param -%}
+		{%- set param_doc = entity.doc.tags.param[param.sym] -%}
+		{%- if (param_doc | length) < 62 -%}
+	  : {{ param_doc }}
+	  {%- else -%}
+	  :
+		{{ param_doc | wrap("		", 62)  }}
+	  {%- endif -%}
+	  {%- endif %}
+	{%- endfor %}
+	{% endif %}
+	{%- if entity.doc.tags.return %}
+	Returns:
+	{%- for ret in entity.doc.tags.return %}
+	{%- set return_doc = entity.doc.tags.return[ret] -%}
+	{%- if (return_doc | length) < 62 %}
+	  _ ({{entity.ret | emit_typespec}}): {{ret}} {{ return_doc }}
+	{%- else %}
+	  _ ({{entity.ret | emit_typespec}}): 
+		{{ret}} {{ return_doc | wrap("		", 62) }}
+	{%- endif %}
+	{% endfor %}
+	{%- endif -%}
+	"""
+{%- endif %}
+	pass

--- a/src/yace/targets/ctypes/entity_function_pointer_decl.h.template
+++ b/src/yace/targets/ctypes/entity_function_pointer_decl.h.template
@@ -1,0 +1,8 @@
+{{ entity.sym }} = FunctionPointer({{entity.ret | emit_typespec}}, 
+{%- for param in entity.parameters -%}
+{{ param.typ | emit_typespec }}{{ "" if loop.last else ", " }}
+{%- endfor -%}
+) 
+{%- if entity.doc.brief -%}
+# {{ entity.doc.brief }}
+{%- endif %}

--- a/src/yace/targets/ctypes/entity_struct_decl.h.template
+++ b/src/yace/targets/ctypes/entity_struct_decl.h.template
@@ -1,0 +1,32 @@
+class {{ entity.sym }}(Structure):
+{%- if entity.doc.__dict__.values()|map("length")|select|first %}
+	"""
+	{% for doc in [entity.doc.brief, entity.doc.description] if doc|length -%}
+	{{ doc | wrap("	") }}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+
+	{%- for tag in entity.doc.tags if tag not in entity.key -%}
+	{% if loop.first and [entity.doc.brief, entity.doc.description]|reject("==","")|list|length %}
+	{# A whitespace between description and tags #}
+	{%- endif -%}
+	{{ tag }}: 
+	{%- for key in entity.doc.tags[tag] %}
+	  {{ key }} {{ entity.doc.tags[tag][key] }}
+	{% endfor -%}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+	"""
+{%- endif %}
+	pass
+
+{{ entity.sym }}._pack_ = 1
+{{ entity.sym }}._fields_ = [
+{%- for member in entity.members %}
+	{% if member.key in ["field", "field_decl"] -%}
+	("{{ member.sym }}", {{ member.typ | emit_typespec }}),
+	{%- endif %}
+{%- endfor %}
+]

--- a/src/yace/targets/ctypes/entity_union_decl.h.template
+++ b/src/yace/targets/ctypes/entity_union_decl.h.template
@@ -1,0 +1,32 @@
+class {{ entity.sym }}(Union):
+{%- if entity.doc.__dict__.values()|map("length")|select|first %}
+	"""
+	{% for doc in [entity.doc.brief, entity.doc.description] if doc|length -%}
+	{{ doc | wrap("	") }}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+
+	{%- for tag in entity.doc.tags if tag not in entity.key -%}
+	{% if loop.first and [entity.doc.brief, entity.doc.description]|reject("==","")|list|length %}
+	{# A whitespace between description and tags #}
+	{%- endif -%}
+	{{ tag }}: 
+	{%- for key in entity.doc.tags[tag] %}
+	  {{ key }} {{ entity.doc.tags[tag][key] }}
+	{% endfor -%}
+	{% if not loop.last %}
+	{% endif %}
+	{%- endfor -%}
+	"""
+{%- endif %}
+	pass
+
+{{ entity.sym }}._pack_ = 1
+{{ entity.sym }}._fields_ = [
+{%- for member in entity.members %}
+	{% if member.key in ["field", "field_decl"] -%}
+	("{{ member.sym }}", {{ member.typ | emit_typespec }}),
+	{%- endif %}
+{%- endfor %}
+]

--- a/src/yace/targets/ctypes/file_api.template
+++ b/src/yace/targets/ctypes/file_api.template
@@ -12,27 +12,12 @@ SPDX-License-Identifier: {{ meta.lic }}
 -------------------------------------------------------------------------------
 NOTE: This file was generated using yace: https://github.com/safl/yace
 """
-from ctypes_sugar import Enum, Structure, Union
+import ctypes
+from ctypes_sugar import Enum, FunctionPointer, Pointer, Structure, Union, check_architecture
 
-{% for entity in entities %}
-{%- if entity.cls in ["define"] -%}
-{{ entity.sym }} = {{ entity.val.lit }} # {{ entity.doc }}
-{%- elif entity.cls in ["enum"] -%}
-class {{ entity.sym }}(Enum):
-	"""{{ entity.doc }}"""
+import {{ meta.prefix }}
 
-{%- for member in entity.members %}
-	{{ member.sym }} = {{ '0x%0x' % member.val.lit }} # {{ member.doc }}
-{%- endfor %}
-{%- elif entity.cls in ["struct", "union"] -%}
-class {{ entity.sym }}({{ "Struct" if entity.cls == "struct" else "Union" }}):
-	"""{{ entity.doc }}"""
-	pass
-{{ entity.sym }}._pack_ = 1
-{{ entity.sym }}._fields_ [
-{%- for member in entity.members %}
-	{% if member.cls == "field" %}("{{ member.sym }}", {{ member | emit_typespec }}),{% endif %}
-{%- endfor %}
-]
-{%- endif %}
+
+{% for entity in entities if entity.key not in ["include_stmt"] -%}
+{{ entity | emit_entity }}
 {% endfor %}

--- a/src/yace/targets/ctypes/file_check.template
+++ b/src/yace/targets/ctypes/file_check.template
@@ -12,11 +12,12 @@ NOTE: This file is auto-generated using yace: https://github.com/safl/yace
 Copyright (C) {{ meta.author }}
 SPDX-License-Identifier: {{ meta.lic }}
 """
-import {{ meta.prefix }}
+from util import check_architecture, load
 
 
 def main():
-	pass
+	check_architecture()
+	load("{{meta.prefix}}")
 
 if __name__ == "__main__":
 	main()

--- a/src/yace/targets/ctypes/init.py
+++ b/src/yace/targets/ctypes/init.py
@@ -1,0 +1,5 @@
+from util import check_architecture, gen_search_paths, load
+
+from . import raw
+
+check_architecture()

--- a/src/yace/targets/ctypes/init_raw.template
+++ b/src/yace/targets/ctypes/init_raw.template
@@ -1,0 +1,4 @@
+from . import {% for module in imports -%}
+{{ module }}
+{{- "" if loop.last else ", " }}
+{%- endfor %}

--- a/src/yace/targets/ctypes/target.py
+++ b/src/yace/targets/ctypes/target.py
@@ -45,6 +45,10 @@ class Ctypes(Target):
 
         transformed = copy.deepcopy(model)
 
+        status = Modulizer(transformed).walk()
+        if not all([res for res in status]):
+            raise TransformationError("The transformation to Python modules failed")
+
         status = Camelizer(transformed).walk()
         if not all([res for res in status]):
             raise TransformationError("The CStyle transformation failed")

--- a/src/yace/targets/ctypes/util.template
+++ b/src/yace/targets/ctypes/util.template
@@ -1,0 +1,78 @@
+"""
+Utility functions for loading the library
+
+* gen_search_paths(libname)
+  * find_library() + pkg-config
+
+* load(libname)
+
+* check_architecture()
+
+Copyright (c) 2023 Simon A. F. Lund <os@safl.dk>
+SPDX-License-Identifier: BSD-3-Clause
+"""
+
+import ctypes
+import ctypes.util
+import os
+import platform
+import subprocess
+
+
+SHARED_EXT = {
+	"linux": "so",
+	"windows": "dll",
+	"darwin": "dylib",
+}
+
+
+def gen_search_paths(libname):
+	"""
+	Yields search-paths for the shared library with the given 'libname'. It is
+	an extension of ``ctypes.util.find_library()`` using ``pkg-config``.
+	"""
+
+	path = ctypes.util.find_library(libname)
+	if path:
+		yield path
+
+	try:
+		proc = subprocess.run(
+			["pkg-config", libname, "--variable=libdir"],
+			check=True,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.PIPE,
+		)
+		if not proc.returncode:
+			ext = SHARED_EXT.get(platform.system().lower(), "so")
+
+			yield os.path.join(
+				proc.stdout.decode("utf-8").strip(), f"lib{libname}.{ext}"
+			)
+	except subprocess.CalledProcessError:
+		pass
+
+
+def load(libname):
+	"""Dynamically load the shared library named 'libname'"""
+
+	for spath in gen_search_paths(libname):
+		try:
+			lib = ctypes.CDLL(spath)
+			if lib:
+				return lib
+		except OSError:
+			continue
+
+	return None
+
+
+def check_architecture():
+	if (
+	{%- for member in ["c_short", "c_int", "c_float", "c_long", "c_longlong", "c_double"] %}
+		{{ "" if loop.first else "or" }} ctypes.sizeof(ctypes.{{member}}) == {{ member | sizeof }}
+	{%- endfor %}
+	):
+		print("FAILED: Wrong architecture; Python binding source architecture does not match target architecture.")
+		exit(1)
+


### PR DESCRIPTION
Jinja templates for unions, structs, enums, functions, function pointers and definitions.

I have changed the ctypes_sugar to be a template too, to be able to check the wordsize on the target machine and compare it to the machine the bindings are built on. Is it the right way I do this? Could also be part of the `file_check` template.

The libraries are not loaded as of now - so I don't use the `load()` function from the ctypes_sugar. Should this be inserted somewhere? And if so, what should be used for the `libname` arg?