### PR TITLE
fix(ci/gha): update the upload-artifacts action to v4

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -71,7 +71,7 @@ jobs:
 #       mv htmlcov output/
 
     - name: Upload generated sources and doxygen
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@v4
       with:
         name: 'archive-${{ matrix.os.name }}-${{ matrix.os.version }}-py${{ matrix.python-version }}'
         path: output/*


### PR DESCRIPTION
v3 was deprecated November 30, 2024.